### PR TITLE
Empty list check (fix name pop errors)

### DIFF
--- a/core/device_stream.py
+++ b/core/device_stream.py
@@ -71,7 +71,8 @@ Capture frames from various sources such as URLs, cameras, monitors, windows, or
         monitor = ["NONE"]
         try:
             monitors = monitor_list()
-            monitors.pop(0)
+            if monitors:  # Check if the list is not empty
+                monitors.pop(0)
             monitor = [f"{i} - {v['width']}x{v['height']}" for i, v in enumerate(monitors.values())]
         except:
             pass
@@ -83,7 +84,9 @@ Capture frames from various sources such as URLs, cameras, monitors, windows, or
 
         names = EnumStreamType._member_names_
         if not JOV_SPOUT:
-            names.pop()
+            if names: # Check if the list is not empty
+                names.pop()
+
 
         d = deep_merge(d, {
             "optional": {


### PR DESCRIPTION
Just a quick and easy fix to avoid the 'pop from empty list' errors that show up in terminal when no device is connected; keeping terminal info cleaner (and avoiding people getting worried about errors, and helping those with us who are a bit OCD from not having to make manual code edits each time we get an update). 


Fixes this error particularly: 
"[ERROR] An error occurred while retrieving information for the 'STREAM READER (JOV) 📺' node.
Traceback (most recent call last):
  File "/home/my_path/ComfyUI/server.py", line 486, in get_object_info
    out[x] = node_info(x)
             ^^^^^^^^^^^^
  File "/home/my_path/ComfyUI/server.py", line 455, in node_info
    info['input_order'] = {key: list(value.keys()) for (key, value) in obj_class.INPUT_TYPES().items()}
                                                                       ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/my_path/ComfyUI/custom_nodes/Jovimetrix/core/device_stream.py", line 86, in INPUT_TYPES
    names.pop()
IndexError: pop from empty list"