### PR TITLE
Add nullcheck to getNickname in node help

### DIFF
--- a/web/core/core_help.js
+++ b/web/core/core_help.js
@@ -107,7 +107,7 @@ app.registerExtension({
                 const firstNodeKey = Object.keys(selectedNodes)[0];
                 const firstNode = selectedNodes[firstNodeKey];
                 const data = {
-                    class: firstNode?.getNickname() || "unknown",
+                    class: firstNode?.getNickname?.() || "unknown",
                     name: firstNode.type
                 }
                 const event = new CustomEvent('jovimetrixHelpRequested', { detail: data });


### PR DESCRIPTION
The node help sidebar feature was not working for me because of this error:

![Selection_307](https://github.com/user-attachments/assets/a8e8dd9c-d598-4aac-8da8-7deba796e0c9)

After adding `getNickname` null check, it works again.