### PR TITLE
skip installing of "PyOpenGL-accelerate" on aarch64 platforms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ numpy>=1.26.4,<2.0.0
 opencv-contrib-python>=4.10.0.84
 Pillow>=10.4.0
 PyOpenGL>=3.1.7
-PyOpenGL-accelerate>=3.1.7
+PyOpenGL-accelerate>=3.1.7; platform_machine == 'x86_64'
 pywin32>=306; platform_system=="Windows"
 requests>=2.32.3
 scikit-image>=0.24.0


### PR DESCRIPTION
Good day.

This is a small PR of a couple of characters, so that the node can be easily installed on macOS with Silicon processors, as well as on Linux with Arm64 CPU.

If packages for arm64 appear here someday, it will be great, but for now there are none:

https://pypi.org/project/PyOpenGL-accelerate/#files

---

I would also like to thank you for your node, how it is implemented and how widely it is configurable.

It is nice to see such an approach, with care for those who will deploy it. 👍